### PR TITLE
Kernel 5.0: ncsi: Fix the handling of Broadcom OEM AEN type 0x80

### DIFF
--- a/net/ncsi/ncsi-aen.c
+++ b/net/ncsi/ncsi-aen.c
@@ -251,7 +251,13 @@ int ncsi_aen_handler(struct ncsi_dev_priv *ndp, struct sk_buff *skb)
 		return -ENOENT;
 	}
 
-	ret = ncsi_validate_aen_pkt(h, nah->payload);
+  if (h->type == NCSI_PKT_AEN_OEM0 &&
+      ntohl(*(__be32 *)(h + 1)) == NCSI_OEM_MFR_BCM_ID) {
+    /* Variable length */
+    ret = ncsi_validate_aen_pkt(h, ntohs(h->common.length)); 
+  } else {  
+	  ret = ncsi_validate_aen_pkt(h, nah->payload);
+  }
 	if (ret) {
 		netdev_warn(ndp->ndev.dev,
 			    "NCSI: 'bad' packet ignored for AEN type 0x%x\n",


### PR DESCRIPTION
Summary:
The NC-SI Broadcom OEM AEN (type 0x80) has a variable payload length per spec.
For example, Host Error AEN can have paylod of 18 bytes. The ncsi_aen_handlers[]
however hardcoded the payload length to 12 byte. This had caused kernel to fail
to verify Broadcom AEN type 0x80 and discarded them. This patch fixes this by
passing the NC-SI payload length from the packet instead of the fixed length
to ncsi_validate_aen_pkt(). This makes process_NCSI_AEN() in ncsid to be able
to receive Broadcom AEN of type 0x80.

Test plan:
- fby3 (pass)
- Send Broadcom AEN type 0x80 (HostError) from NIC to BMC and check the BCM
  Host Error log (pass).
  In /var/log/messages
    2021 Feb 7 18:14:37 dhcp-10-123-28-110.dhcp.broadcom.net user.crit fby3-da3230fb20-dirty: ncsid: NIC Event: , BCM Host Error, HostId=0x4 DownCnt=0x0001
  In log-util
    0 all 2021-02-07 18:14:37 ncsid NIC Event: , BCM Host Error, HostId=0x4 DownCnt=0x0001